### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ values.
 # Installing
 
 ```
-jpm install https://github.com/mikebeller/janet-set.git
+jpm install set
 ```
 
 ## License


### PR DESCRIPTION
Since janet-set is in [pkgs](https://github.com/janet-lang/pkgs), you can install it using its unadorned/short name.